### PR TITLE
Sonar fixes

### DIFF
--- a/framework/TSA/Factory.py
+++ b/framework/TSA/Factory.py
@@ -21,6 +21,7 @@ from EntityFactoryBase import EntityFactory
 from .TimeSeriesAnalyzer import TimeSeriesAnalyzer
 from .Fourier import Fourier
 from .ARMA import ARMA
+from .RWD import RWD
 from .Wavelet import Wavelet
 from .PolynomialRegression import PolynomialRegression
 
@@ -28,5 +29,6 @@ factory = EntityFactory('TimeSeriesAnalyzer')
 # TODO map lower case to upper case, because of silly ROM namespace problems
 aliases = {'Fourier': 'fourier',
            'ARMA': 'arma',
+           'RWD': 'rwd',
            'Wavelet': 'wavelet'}
 factory.registerAllSubtypes(TimeSeriesAnalyzer, alias=aliases)

--- a/framework/TSA/RWD.py
+++ b/framework/TSA/RWD.py
@@ -1,0 +1,252 @@
+# Copyright 2017 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+  Randomized Window Decomposition
+"""
+
+import collections
+import numpy as np
+import scipy as sp
+import Decorators
+import string
+import numpy.linalg as LA
+import pandas as pd
+import copy as cp
+
+
+from utils import InputData, InputTypes, randomUtils, xmlUtils, mathUtils, importerUtils
+statsmodels = importerUtils.importModuleLazy('statsmodels', globals())
+
+import Distributions
+from .TimeSeriesAnalyzer import TimeSeriesGenerator, TimeSeriesCharacterizer
+
+# utility methods
+class RWD(TimeSeriesGenerator,TimeSeriesCharacterizer):
+  r"""
+    Randomized Window Decomposition
+  """
+
+
+  @classmethod
+  def getInputSpecification(cls):
+    """
+      Method to get a reference to a class that specifies the input data for
+      class cls.
+      @ Out, inputSpecification, InputData.ParameterInput, class to use for
+        specifying input of cls.
+    """
+    specs = super(RWD, cls).getInputSpecification()
+    specs.name = 'rwd'
+    specs.description = r"""TimeSeriesAnalysis algorithm for sliding window snapshots to generate features"""
+
+    specs.addSub(InputData.parameterInputFactory('signatureWindowLength', contentType=InputTypes.IntegerType,
+                 descr=r"""the size of signature window, which represents as a snapshot for a certain time step;
+                       typically represented as $w$ in literature, or $w_sig$ in the code."""))
+    specs.addSub(InputData.parameterInputFactory('featureIndex', contentType=InputTypes.IntegerType,
+                 descr=r""" Index used for feature selection, which requires pre-analysis for now, will be addresses
+                 via other non human work required method """))
+    specs.addSub(InputData.parameterInputFactory('sampleType', contentType=InputTypes.IntegerType,
+                 descr=r"""Indicating the type of sampling."""))
+    specs.addSub(InputData.parameterInputFactory('seed', contentType=InputTypes.IntegerType,
+                 descr=r"""Indicating random seed."""))
+    return specs
+
+
+  #
+  # API Methods
+  #
+  def __init__(self, *args, **kwargs):
+    """
+      A constructor that will appropriately intialize a supervised learning object
+      @ In, args, list, an arbitrary list of positional values
+      @ In, kwargs, dict, an arbitrary dictionary of keywords and values
+      @ Out, None
+    """
+    # general infrastructure
+    super().__init__(*args, **kwargs)
+    self._minBins = 20 # this feels arbitrary; used for empirical distr. of data
+
+  def handleInput(self, spec):
+    """
+      Reads user inputs into this object.
+      @ In, inp, InputData.InputParams, input specifsications
+      @ In, sampleType, integer = 0, 1, 2
+      @     sampleType = 0: Sequentially Sampling
+      @     sampleType = 1: Randomly Sampling
+      @     sampleType = 2: Piecewise Sampling
+      @ Out, settings, dict, initialization settings for this algorithm
+    """
+    settings = super().handleInput(spec)
+    settings['signatureWindowLength'] = spec.findFirst('signatureWindowLength').value
+    settings['featureIndex'] = spec.findFirst('featureIndex').value
+    settings['sampleType'] = spec.findFirst('sampleType').value
+    return settings
+
+  def setDefaults(self, settings):
+    """
+      Fills default values for settings with default values.
+      @ In, settings, dict, existing settings
+      @ Out, settings, dict, modified settings
+    """
+    settings = super().setDefaults(settings)
+    if 'signatureWindowLength' not in settings:
+      settings['signatureWindowLength'] = None
+      settings['sampleType'] = 1
+    if 'engine' not in settings:
+      settings['engine'] = randomUtils.newRNG()
+    if 'seed' not in settings:
+      settings['seed'] = 42
+    return settings ####
+
+  def characterize(self, signal, pivot, targets, settings):
+    """
+      Determines the charactistics of the signal based on this algorithm.
+      @ In, signal, np.ndarray, time series with dims [time, target]
+      @ In, pivot, np.1darray, time-like parameter values
+      @ In, targets, list(str), names of targets in same order as signal
+      @ In, settings, dict, settings for this ROM
+      @ Out, params, dict of dict: 1st level contains targets/variables; 2nd contains: U vectors and features
+    """
+    # lazy import statsmodels
+    import statsmodels.api
+    # settings:
+    #   signatureWindowLength, int,  Signature window length
+    #   featureIndex, list of int,  The index that contains differentiable params
+    seed = settings['seed']
+    if seed is not None:
+      randomUtils.randomSeed(seed, engine=settings['engine'], seedBoth=True)
+
+    params = {}
+
+    for tg, target in enumerate(targets):
+      history = signal[:, tg]
+      if settings['signatureWindowLength'] is None:
+        settings['signatureWindowLength'] = len(history)//10
+      signatureWindowLength = int(settings['signatureWindowLength'])
+      fi = int(settings['featureIndex'])
+      sampleType = settings['sampleType']
+      allWindowNumber = int(len(history)-signatureWindowLength+1)
+
+      signatureMatrix = np.zeros((signatureWindowLength, allWindowNumber))
+      for i in range(allWindowNumber):
+        signatureMatrix[:,i] = np.copy(history[i:i+signatureWindowLength])
+
+      # Sequential sampling
+      if sampleType == 0:
+        baseMatrix = np.copy(signatureMatrix)
+
+      # Randomized sampling
+      elif sampleType == 1:
+        sampleLimit = len(history)-signatureWindowLength
+        windowNumber = sampleLimit//4
+        baseMatrix = np.zeros((signatureWindowLength, windowNumber))
+        for i in range(windowNumber):
+          windowIndex = randomUtils.randomIntegers(0, sampleLimit, caller=None)
+          baseMatrix[:,i] = np.copy(history[windowIndex:windowIndex+signatureWindowLength])
+
+      # Piecewise Sampling
+      elif sampleType == 2:
+        windowNumber = len(history)//signatureWindowLength
+        baseMatrix = np.zeros((signatureWindowLength, windowNumber))
+        for i in range(windowNumber-1):
+          baseMatrix[:,i] = np.copy(history[i*signatureWindowLength:(i+1)*signatureWindowLength])
+      U,s,V = mathUtils.computeTruncatedSingularValueDecomposition(baseMatrix,fi)
+      featureMatrix = U.T @ signatureMatrix
+      params[target] = {'uVec'        : U[:,0:fi],
+                        'Feature'     : featureMatrix[0:fi],
+                        'featurePivot': np.arange(allWindowNumber)}
+    return params
+
+
+  def getParamNames(self, settings):
+    """
+      Return list of expected variable names based on the parameters
+      @ In, settings, dict, training parameters for this algorithm
+      @ Out, names, list, string list of names
+    """
+    names = []
+    for target in settings['target']:
+      base = f'{self.name}__{target}'
+      sw = int(settings['signatureWindowLength'])
+      fi = int(settings['featureIndex'])
+      for i in range(fi):
+        for j in range(sw):
+          names.append(f'{base}__uVec{i}_{j}')
+    return names
+
+  def getParamsAsVars(self, params):
+    """
+      Map characterization parameters into flattened variable format
+      @ In, params, dict, trained parameters (as from characterize)
+      @ Out, rlz, dict, realization-style response
+    """
+    rlz = {}
+    for target, info in params.items():
+      base = f'{self.name}__{target}'
+      (k,l) = (info['uVec']).shape
+      for i in range(l):
+        for j in range(k):
+          rlz[f'{base}__uVec{i}_{j}'] = info['uVec'][j,i]
+    return rlz
+
+
+
+  def generate(self, params, pivot, settings):
+    """
+      Generates a synthetic history from fitted parameters.
+      @ In, params, dict, characterization such as otained from self.characterize()
+      @ In, pivot, np.array(float), pivot parameter values
+      @ In, settings, dict, additional settings specific to algorithm
+      @ Out, synthetic, np.array(float), synthetic estimated model signal
+      
+      Store the features in this generate
+      
+    """
+    
+    pivotF = len(params[target]['Feature'][0])
+    numberF = len(params[target]['Feature'])
+    synthetic = np.zeros((len(pivot_f*numberF), len(params)))
+    for t, (target, _) in enumerate(params.items()):
+      sigMatSynthetic =  params[target]['Feature']
+      synthetic[:, t] = sigMatSynthetic.flatten()
+    
+    #synthetic = params[target]['Feature']
+
+    
+    '''
+    synthetic = np.zeros((len(pivot), len(params)))
+    for t, (target, _) in enumerate(params.items()):
+      sigMatSynthetic = params[target]['uVec'] @ params[target]['Feature']
+      synthetic[:, t] = np.hstack((sigMatSynthetic[0,:-1], sigMatSynthetic[:,-1]))
+    '''
+
+    return synthetic
+
+  def writeXML(self, writeTo, params):
+    """
+      Allows the engine to put whatever it wants into an XML to print to file.
+      @ In, writeTo, xmlUtils.StaticXmlElement, entity to write to
+      @ In, params, dict, params from as from self.characterize
+      @ Out, None
+    """
+    counter = 0
+    for target, info in params.items():
+      base = xmlUtils.newNode(target)
+      writeTo.append(base)
+      (m,n) = info["uVec"].shape
+      for i in range(n):
+        U0 = info["uVec"][:,0]
+        counter +=1
+        for p, ar in enumerate(U0):
+          base.append(xmlUtils.newNode(f'uVec{i}_{p}', text=f'{float(ar):1.9e}'))

--- a/framework/TSA/__init__.py
+++ b/framework/TSA/__init__.py
@@ -22,7 +22,7 @@ from .TimeSeriesAnalyzer import TimeSeriesAnalyzer
 
 from .Fourier import Fourier
 from .ARMA import ARMA
-
+from .RWD import RWD
 from .Factory import factory
 
 from .TSAUser import TSAUser # needs to be imported AFTER factory!

--- a/tests/framework/unit_tests/TSA/testRWD.py
+++ b/tests/framework/unit_tests/TSA/testRWD.py
@@ -1,0 +1,289 @@
+# Copyright 2017 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+  This Module performs Unit Tests for the TSA.RWD class.
+  It can not be considered part of the active code but of the regression test system
+"""
+import os
+import sys
+import copy
+import numpy as np
+
+
+# add RAVEN to path
+frameworkDir = os.path.abspath(os.path.join(*([os.path.dirname(__file__)] + [os.pardir]*4 + ['framework'])))
+if frameworkDir not in sys.path:
+  sys.path.append(frameworkDir)
+
+from utils.utils import find_crow
+find_crow(frameworkDir)
+import numpy.linalg as LA
+
+from utils import xmlUtils
+
+from TSA import RWD
+
+plot = False
+
+print('Module undergoing testing:')
+print(RWD)
+print('')
+
+results = {"pass":0,"fail":0}
+
+def checkFloat(comment, value, expected, tol=1e-10, update=True):
+  """
+    This method is aimed to compare two floats given a certain tolerance
+    @ In, comment, string, a comment printed out if it fails
+    @ In, value, float, the value to compare
+    @ In, expected, float, the expected value
+    @ In, tol, float, optional, the tolerance
+    @ In, update, bool, optional, if False then don't update results counter
+    @ Out, res, bool, True if same
+  """
+  if np.isnan(value) and np.isnan(expected):
+    res = True
+  elif np.isnan(value) or np.isnan(expected):
+    res = False
+  else:
+    res = abs(value - expected) <= tol
+  if update:
+    if not res:
+      print("checking float",comment,'|',value,"!=",expected)
+      results["fail"] += 1
+    else:
+      results["pass"] += 1
+  return res
+
+def checkTrue(comment, res, update=True):
+  """
+    This method is a pass-through for consistency and updating
+    @ In, comment, string, a comment printed out if it fails
+    @ In, res, bool, the tested value
+    @ In, update, bool, optional, if False then don't update results counter
+    @ Out, res, bool, True if test
+  """
+  if update:
+    if res:
+      results["pass"] += 1
+    else:
+      print("checking bool",comment,'|',res,'is not True!')
+      results["fail"] += 1
+  return res
+
+def checkSame(comment, value, expected, update=True):
+  """
+    This method is aimed to compare two identical things
+    @ In, comment, string, a comment printed out if it fails
+    @ In, value, float, the value to compare
+    @ In, expected, float, the expected value
+    @ In, update, bool, optional, if False then don't update results counter
+    @ Out, res, bool, True if same
+  """
+  res = value == expected
+  if update:
+    if res:
+      results["pass"] += 1
+    else:
+      print("checking string",comment,'|',value,"!=",expected)
+      results["fail"] += 1
+  return res
+
+def checkArray(comment, first, second, dtype, tol=1e-10, update=True):
+  """
+    This method is aimed to compare two arrays
+    @ In, comment, string, a comment printed out if it fails
+    @ In, value, float, the value to compare
+    @ In, expected, float, the expected value
+    @ In, tol, float, optional, the tolerance
+    @ In, update, bool, optional, if False then don't update results counter
+    @ Out, res, bool, True if same
+  """
+  res = True
+  if len(first) != len(second):
+    res = False
+    print("checking answer",comment,'|','lengths do not match:',len(first),len(second))
+  else:
+    for i in range(len(first)):
+      if dtype == float:
+        pres = checkFloat('',first[i],second[i],tol,update=False)
+      elif dtype in (str,unicode):
+        pres = checkSame('',first[i],second[i],update=False)
+      if not pres:
+        print('checking array',comment,'|','entry "{}" does not match: {} != {}'.format(i,first[i],second[i]))
+        res = False
+  if update:
+    if res:
+      results["pass"] += 1
+    else:
+      results["fail"] += 1
+  return res
+
+def checkNone(comment, entry, update=True):
+  """
+    Checks if entry is None.
+    @ In, comment, string, a comment printed out if it fails
+    @ In, entry, object, to test if against None
+    @ In, update, bool, optional, if False then don't update results counter
+    @ Out, res, bool, True if None
+  """
+  res = entry is None
+  if update:
+    if res:
+      results["pass"] += 1
+    else:
+      print("checking answer",comment,'|','"{}" is not None!'.format(entry))
+      results["fail"] += 1
+
+def checkFails(comment, errstr, function, update=True, args=None, kwargs=None):
+  """
+    Checks if expected error occurs
+    @ In, comment, string, a comment printed out if it fails
+    @ In, errstr, str, expected fail message
+    @ In, function, method, method to run to test for failure
+    @ In, update, bool, optional, if False then don't update results counter
+    @ In, args, list, arguments to pass to function
+    @ In, kwargs, dict, keyword arguments to pass to function
+    @ Out, res, bool, True if failed as expected
+  """
+  print('Error testing ...')
+  if args is None:
+    args = []
+  if kwargs is None:
+    kwargs = {}
+  try:
+    function(*args,**kwargs)
+    res = False
+    msg = 'Function call did not error!'
+  except Exception as e:
+    res = checkSame('',e.args[0],errstr,update=False)
+    if not res:
+      msg = 'Unexpected error message.  \n    Received: "{}"\n    Expected: "{}"'.format(e.args[0],errstr)
+  if update:
+    if res:
+      results["pass"] += 1
+      print(' ... end Error testing (PASSED)')
+    else:
+      print("checking error",comment,'|',msg)
+      results["fail"] += 1
+      print(' ... end Error testing (FAILED)')
+  print('')
+  return res
+
+
+######################################
+#            CONSTRUCTION            #
+######################################
+def createRWDXML(targets, signatureWindowLength, featureIndex, sampleType):
+  xml = xmlUtils.newNode('RWD', attrib={'target':','.join(targets)})
+  xml.append(xmlUtils.newNode('signatureWindowLength', text=f'{signatureWindowLength}'))
+  xml.append(xmlUtils.newNode('featureIndex', text=f'{featureIndex}'))
+  xml.append(xmlUtils.newNode('sampleType', text=f'{sampleType}'))
+  return xml
+
+def createFromXML(xml):
+  print(vars(RWD))
+  rwd = RWD()
+
+  inputSpec = rwd.getInputSpecification()()
+  inputSpec.parseNode(xml)
+  rwd.handleInput(inputSpec)
+  return rwd
+
+def createRWD(targets, signatureWindowLength, featureIndex, sampleType):
+  xml = createRWDXML(targets, signatureWindowLength, featureIndex, sampleType)
+  print('createRWDXML passed')
+  rwd = createFromXML(xml)
+  print('createFromXML passed')
+  return rwd
+
+'''
+def createRWDWindowSignal(settings, pivot, plot=False):
+  if plot:
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots()
+  featureIndex = settings['featureIndex']
+  windowSize = settings['signatureWindowLength']
+  allWindowNumber = len(pivot)-windowSize+1
+  signal = np.zeros((allWindowNumber, featureIndex))
+  if plot:
+    ax.plot(pivot, noise, 'k:')
+    ax.plot(pivot, signal, 'g.-')
+    plt.show()
+
+  return signal
+'''
+
+###################
+#  Simple         #
+###################
+# generate signal
+targets = ['A'] 
+pivot = np.linspace(0, 100, 1000)
+N = len(pivot)
+s = np.linspace(-10,10,1000)
+time_series = 3.5*s+s**2+10
+
+
+signals = np.zeros((len(pivot), 1))
+signals[:, 0] = time_series
+
+##########
+# Simplest reasonable case
+#########
+rwd = createRWD(targets, 105, 3,0)
+settings = {'signatureWindowLength':105, 'featureIndex': 3, 'sampleType' : 0, 'seed': 42}
+if 'signatureWindowLength' not in settings:
+  print('signatureWindowLength is not in settings')
+settings = rwd.setDefaults(settings)
+params = rwd.characterize(signals, pivot, targets, settings)
+check = params['A']
+
+
+
+# code to generate answer
+signatureWindowLength = 105
+history = np.copy(time_series)
+sampleLimit = len(history)-signatureWindowLength
+windowNumber = sampleLimit//4
+sampleIndex = np.random.randint(sampleLimit, size=windowNumber)
+baseMatrix = np.zeros((signatureWindowLength, windowNumber))
+for i in range(windowNumber):
+  windowIndex = sampleIndex[i]
+  baseMatrix[:,i] = np.copy(history[windowIndex:windowIndex+signatureWindowLength])
+
+allwindowNumber = len(history)-signatureWindowLength+1
+signatureMatrix = np.zeros((signatureWindowLength, allwindowNumber))
+
+for i in range(allwindowNumber):
+  signatureMatrix[:,i] = np.copy(history[i:i+signatureWindowLength])
+
+baseMatrix = np.copy(signatureMatrix)
+U,S,V = LA.svd(baseMatrix,full_matrices=False)
+assert np.allclose(baseMatrix, np.dot(U, np.dot(np.diag(S), V)))
+
+
+F = U.T @ signatureMatrix
+okay_basis = U[:,0]
+okay_feature = F[0:3,0]
+
+
+checkArray('Simple RWD Basis', okay_basis, check['uVec'][:,0], float, tol=1e-3)
+checkArray('Simple RWD Features', okay_feature, check['Feature'][0:3,0], float, tol=1e-3)
+checkTrue("RWD can characterize", rwd.canCharacterize())
+checkTrue("RWD can characterize", rwd.canGenerate())
+
+print(results)
+
+sys.exit(results["fail"])


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

